### PR TITLE
Docs/tests: orchestrator specs and test cleanup

### DIFF
--- a/docs_v2/01_Overview/README.md
+++ b/docs_v2/01_Overview/README.md
@@ -1,10 +1,12 @@
 # Social Media Publisher — V2 Documentation Set
 
 Version: 2.3  
-Last Updated: December 21, 2025  
-Status: Approved for implementation
+Last Updated: December 30, 2025  
+Status: Canonical docs (live; maintained)
 
-This folder contains the complete documentation to implement a brand‑new, modernized solution that preserves Dropbox for storage while upgrading AI, architecture, and publishing flows.
+**Canonical entrypoint:** `docs_v2/README.md`
+
+This folder provides a reading-oriented overview of the V2 documentation set.
 
 Contents:
 - `03_Architecture/SYSTEM_DESIGN.md` — System overview, goals, scope, user journeys
@@ -12,13 +14,20 @@ Contents:
 - `02_Specifications/USER_FLOW.md` — End‑to‑end flows, sequence diagrams, UX behaviors
 - `02_Specifications/SPECIFICATION.md` — Complete implementation spec (APIs, contracts, data models)
 - `02_Specifications/ORCHESTRATOR_SERVICE_API_INTEGRATION_GUIDE.md` — Orchestrator service-to-service API integration (when using platform orchestrator)
+- `02_Specifications/ORCHESTRATOR_RUNTIME_CONFIG_SCHEMA_REFERENCE.md` — Canonical orchestrator runtime config schema + GUI validation rules
 - `07_AI/AI_PROMPTS_AND_MODELS.md` — Model choices, prompting strategies, evaluation
-- `05_Configuration/CONFIGURATION.md` — Environment, INI schema, pydantic validation
+- `05_Configuration/CONFIGURATION.md` — Configuration model (orchestrator-default), env/INI compatibility, validation
 - `08_Epics/000_v2_foundation/000_preview_mode/000_feature.md` — Preview mode guarantees (no side effects)
 - `04_Security_Privacy/SECURITY_PRIVACY.md` — Security posture, secrets, sessions, PII, logging
 - `06_NFRs/NFRS.md` — Non‑functional requirements and targets
 
-Start with SYSTEM_DESIGN.md, then read SPECIFICATION.md and ARCHITECTURE.md. AI coders can safely implement using SPECIFICATION.md alone, with ARCHITECTURE.md and CONFIGURATION.md as reference.
+Suggested reading order:
+
+1. `docs_v2/README.md` (navigation)
+2. `03_Architecture/SYSTEM_DESIGN.md`
+3. `03_Architecture/ARCHITECTURE.md`
+4. `05_Configuration/CONFIGURATION.md` (orchestrator-default)
+5. `02_Specifications/SPECIFICATION.md` (implementation details)
 
 Notable capabilities:
 - Stable‑Diffusion‑ready caption sidecar (`<image>.txt`) generated alongside normal captions

--- a/docs_v2/02_Specifications/ORCHESTRATOR_RUNTIME_CONFIG_SCHEMA_REFERENCE.md
+++ b/docs_v2/02_Specifications/ORCHESTRATOR_RUNTIME_CONFIG_SCHEMA_REFERENCE.md
@@ -1,0 +1,436 @@
+# Orchestrator Runtime Config Schema Reference — Publisher V2 (GUI Validation Contract)
+
+Version: 1.0  
+Last Updated: December 30, 2025
+
+This document is the **canonical, field-level contract** for the **orchestrator-managed runtime configuration** consumed by **Publisher V2**.  
+It is intended for the **orchestrator team** to build an end-user GUI with **explicit validation**.
+
+Scope:
+
+- Runtime config envelope returned from `/v1/runtime/by-host` (**non-secret**)
+- Schema v2 `config` blocks, their **required/optional** fields, and **allowed values**
+- Credentials resolution responses from `/v1/credentials/resolve` (**secret**, never stored in runtime config)
+
+Not in scope:
+
+- Host normalization rules (see `ORCHESTRATOR_SERVICE_API_INTEGRATION_GUIDE.md`)
+- Auth, rate limiting, retries (see `ORCHESTRATOR_SERVICE_API_INTEGRATION_GUIDE.md`)
+
+---
+
+## 1) High-level rules (non-negotiable)
+
+1. **No secrets in runtime config**  
+   Runtime config must not contain secret material (OpenAI API keys, refresh tokens, SMTP passwords, Telegram bot tokens).
+2. **Secrets are references**  
+   Secrets are delivered only via `/v1/credentials/resolve` using:
+   - `credentials_ref` (general secret reference)
+   - `password_ref` (SMTP password reference; still resolved via `/v1/credentials/resolve`)
+3. **Publisher V2 currently supports only these orchestrator-managed publishers**:
+   - `telegram`
+   - `fetlife` (implemented via SMTP/email)
+
+   Other publisher types may exist in orchestrator, but **Publisher V2 ignores them** today.
+4. **“Enabled” is authoritative**  
+   The GUI must prevent enabling an item unless all of its required fields are valid.
+
+---
+
+## 2) Endpoints (service API surface)
+
+Canonical integration guide:
+
+- `docs_v2/02_Specifications/ORCHESTRATOR_SERVICE_API_INTEGRATION_GUIDE.md`
+
+Publisher behavior (current implementation):
+
+- Runtime config lookup:
+  - **Preferred**: `POST /v1/runtime/by-host` with body `{ "host": "<normalized_host>" }`
+  - **Fallback**: `GET /v1/runtime/by-host?host=<normalized_host>` (only if POST returns 405)
+- Credentials resolution:
+  - `POST /v1/credentials/resolve` with:
+    - header `X-Tenant: <tenant>`
+    - body `{ "credentials_ref": "<opaque-ref>" }`
+
+---
+
+## 3) Runtime response envelope (schema v2)
+
+Publisher expects the orchestrator to return this envelope:
+
+| Field | Type | Required | Allowed / Notes |
+|------|------|----------|-----------------|
+| `schema_version` | int | ✅ | **2** for schema v2 (Publisher still supports v1 for backward compatibility) |
+| `tenant` | string | ✅ | Tenant slug returned by orchestrator (Publisher treats as opaque string) |
+| `app_type` | string | ✅ | Must be **`"publisher_v2"`** |
+| `config_version` | string | ✅ | Opaque version token; changes whenever config changes |
+| `ttl_seconds` | int | ✅ | Cache TTL in seconds (default 600). Must be positive. |
+| `config` | object | ✅ | Schema v2 config object (next section) |
+
+### 3.1 Caching semantics (important for GUI + operator expectations)
+
+- `ttl_seconds` controls Publisher’s in-memory cache lifetime per host.
+- Publisher may serve **stale cached config** when orchestrator is temporarily unavailable.
+
+---
+
+## 4) `config` object (schema v2)
+
+Schema v2 extends schema v1 by including additional non-secret blocks needed for full Publisher operation.
+
+Top-level required blocks:
+
+- `features` (required)
+- `storage` (required)
+
+Note:
+
+- Some admin UIs edit individual non-secret blocks (e.g., `ai`, `publishers`, `email_server`) in isolation.  
+  This document describes the **full runtime payload** Publisher consumes; the orchestrator’s `/v1/runtime/by-host` response must still include `features` and `storage`.
+
+Additional blocks (schema v2):
+
+- `publishers` (optional array; defaults to empty)
+- `email_server` (optional; required when enabling `fetlife`)
+- `ai` (optional; required when enabling AI analysis)
+- `captionfile` (optional; **required when enabling AI analysis**)
+- `confirmation` (optional; **required when enabling AI analysis**)
+- `content` (optional; **platform-managed defaults** — do not expose to end users)
+
+---
+
+## 4.0) Feature ↔ configuration dependency rules (GUI gating)
+
+This section defines **when configuration blocks are required**, based on `config.features.*`.
+
+Goal:
+
+- The orchestrator GUI should **only ask for data that will be used**.
+- The GUI must prevent enabling a feature unless the required config (and credential refs) are present and valid.
+
+Terminology:
+
+- **Required**: the GUI must not allow saving `enabled=true` / feature toggle `true` unless the required block/field is valid.
+- **Optional**: may be omitted; Publisher will apply defaults.
+- **Ignored**: may be present, but Publisher will not use it because the governing feature is off.
+
+### 4.0.0 Recommended GUI flow (short)
+
+Suggested order for an orchestrator admin UI that edits schema v2 blocks:
+
+1. **Storage (required first)**
+   - Collect `storage.provider="dropbox"`, `storage.credentials_ref`, and `storage.paths.root` (and optional `archive/keep/remove`).
+2. **Features toggles**
+   - Set `features.publish_enabled` and `features.analyze_caption_enabled` early; they control which sections should be shown/required.
+3. **AI (only if analyze is enabled)**
+   - If `analyze_caption_enabled=true`, require:
+     - `ai.credentials_ref`
+     - `captionfile` block (may be defaults)
+     - `confirmation` block (may be defaults)
+   - If `false`, hide/disable `ai`, `captionfile`, and `confirmation`.
+4. **Publishers (only if publish is enabled)**
+   - If `publish_enabled=true`, require at least one enabled publisher entry.
+   - If `false`, hide/disable `publishers` and related secret refs (telegram/smtp).
+5. **Email server (only if FetLife enabled)**
+   - If an enabled `fetlife` publisher exists, require `email_server.host`, `email_server.from_email`, and `email_server.password_ref`.
+6. **Optional finishing blocks**
+   - `content` should be treated as **platform defaults** (not user-editable).
+
+### 4.0.1 Always required (for any usable Publisher V2 tenant)
+
+Even for “review-only” tenants, Publisher must still be able to **read images**. Therefore, these are always required in the full runtime payload:
+
+- `config.features` (all fields present)
+- `config.storage`:
+  - `provider="dropbox"`
+  - `credentials_ref` (non-empty string)
+  - `paths.root` (absolute Dropbox path starting with `/`, no `..`)
+
+Notes:
+
+- Publisher currently resolves Dropbox credentials **eagerly** during config load. If `storage.credentials_ref` cannot be resolved, the tenant is effectively down.
+
+### 4.0.2 AI captioning / analysis (`features.analyze_caption_enabled`)
+
+If `config.features.analyze_caption_enabled = true`:
+
+- **Required**
+  - `config.ai.credentials_ref` (non-empty string; resolves to OpenAI API key via `/v1/credentials/resolve` provider `openai`)
+- **Required**
+  - `config.captionfile` (may use defaults; required so the orchestrator UI makes the dependency explicit)
+  - `config.confirmation` (may use defaults; required so the orchestrator UI makes the dependency explicit)
+- **Optional**
+  - Other `config.ai` fields (`vision_model`, `caption_model`, prompts, `sd_caption_*`) to override defaults
+- **Required (implicit gating)**
+  - The orchestrator GUI should also ensure the referenced OpenAI credential exists for the tenant (via its own control-plane validation), but this is enforced at runtime by Publisher.
+
+If `config.features.analyze_caption_enabled = false`:
+
+- `config.ai`, `config.captionfile`, and `config.confirmation` may be omitted and should not be requested in the GUI.
+
+### 4.0.3 Publishing (`features.publish_enabled`)
+
+If `config.features.publish_enabled = true`:
+
+- **Required**
+  - `config.publishers` must contain **at least one** entry with `enabled=true` and a supported `type` (`telegram` or `fetlife`).
+  - The GUI should require at least one enabled publisher; otherwise “publish” is enabled but has nowhere to publish.
+
+If `config.features.publish_enabled = false`:
+
+- `config.publishers` / `config.email_server` / publisher credential refs are **not required** and should not be requested.
+- If present, they are effectively **ignored** because publishing is disabled.
+
+### 4.0.4 Publisher-specific requirements (when that publisher is enabled)
+
+The following rules apply only when BOTH:
+
+- `config.features.publish_enabled = true`, AND
+- there is a matching `config.publishers[]` entry with `enabled=true`.
+
+#### A) Telegram publisher
+
+Required:
+
+- Publisher entry with:
+  - `type="telegram"`
+  - `enabled=true`
+  - `credentials_ref` (non-empty string; resolves to provider `telegram`)
+  - `config.channel_id` (non-empty string)
+
+#### B) FetLife publisher (SMTP/email)
+
+Required:
+
+- Publisher entry with:
+  - `type="fetlife"`
+  - `enabled=true`
+  - `credentials_ref` **must be null or omitted**
+  - `config.recipient` (non-empty string)
+  - Optional enums:
+    - `config.caption_target ∈ {"subject","body","both"}`
+    - `config.subject_mode ∈ {"normal","private","avatar"}`
+- `config.email_server` present with:
+  - `host` (non-empty string)
+  - `from_email` (non-empty string)
+  - `password_ref` (non-empty string; resolves to provider `smtp`)
+  - `port` optional (defaults 587)
+
+Notes:
+
+- Confirmation behavior comes from `config.confirmation` (optional; defaults apply if omitted).
+
+### 4.0.5 Curation (`features.keep_enabled` / `features.remove_enabled`)
+
+If `keep_enabled=true` and/or `remove_enabled=true`:
+
+- No additional config blocks are required beyond `config.storage`.
+- If `storage.paths.keep/remove` are omitted, Publisher will derive defaults under `paths.root` (`keep` / `reject`).
+
+### 4.0.6 Auto-view (`features.auto_view_enabled`)
+
+- No additional config is required. This only affects web UI access rules.
+
+### 4.1 `config.features`
+
+| Field | Type | Required | Default | Notes |
+|------|------|----------|---------|------|
+| `publish_enabled` | bool | ✅ | `false` | Governs publishing (CLI + web) |
+| `analyze_caption_enabled` | bool | ✅ | `false` | Governs AI analysis + caption generation |
+| `keep_enabled` | bool | ✅ | `true` | Enables Keep curation action |
+| `remove_enabled` | bool | ✅ | `true` | Enables Remove curation action |
+| `auto_view_enabled` | bool | ✅ | `false` | Allows non-admin random viewing in web UI |
+
+### 4.2 `config.storage`
+
+| Field | Type | Required | Allowed / Notes |
+|------|------|----------|-----------------|
+| `provider` | string | ✅ | **Must be `"dropbox"`** (only supported provider today) |
+| `credentials_ref` | string | ✅ | Opaque reference resolved to Dropbox refresh token |
+| `paths` | object | ✅ | Storage paths (below) |
+
+#### 4.2.1 `config.storage.paths`
+
+| Field | Type | Required | Allowed / Notes |
+|------|------|----------|-----------------|
+| `root` | string | ✅ | Must start with `/`. Must not contain `..` path component. |
+| `archive` | string \| null | ❌ | If relative, it is resolved under `root`. Default suffix: `archive`. Must not contain `..`. |
+| `keep` | string \| null | ❌ | If relative, it is resolved under `root`. Default suffix: `keep`. Must not contain `..`. |
+| `remove` | string \| null | ❌ | If relative, it is resolved under `root`. Default suffix: `reject`. Must not contain `..`. |
+
+Notes:
+
+- These are Dropbox paths (not local filesystem paths).
+- `content.archive` (boolean) is different from `storage.paths.archive` (path).
+
+### 4.3 `config.publishers[]`
+
+Publisher list entries have this shape:
+
+| Field | Type | Required | Notes |
+|------|------|----------|------|
+| `id` | string | ✅ | Stable identifier (used by orchestrator/UI) |
+| `type` | string | ✅ | Allowed: `telegram`, `fetlife` |
+| `enabled` | bool | ✅ | Default `true` |
+| `credentials_ref` | string \| null | ❌ | Required for `telegram`; for `fetlife` it must be `null` **or omitted** |
+| `config` | object | ✅ | Type-specific config block |
+
+Important behavior:
+
+- Publisher only consumes the **first enabled entry** of each supported type.
+- Additional enabled entries of the same type are currently **ignored** by Publisher V2.
+
+#### 4.3.1 Publisher type: `telegram`
+
+Required:
+
+- `enabled=true`
+- `credentials_ref` (non-empty string)
+- `config.channel_id` (non-empty string)
+
+Config fields:
+
+| Field | Type | Required | Notes |
+|------|------|----------|------|
+| `channel_id` | string | ✅ | Passed directly to Telegram API (`chat_id`) |
+
+#### 4.3.2 Publisher type: `fetlife` (SMTP/email)
+
+Required:
+
+- `enabled=true`
+- `credentials_ref=null` (**must be null or omitted**)  
+  FetLife does not have a direct secret; SMTP auth is provided via `email_server.password_ref`.
+- `config.recipient` (non-empty string)
+- `email_server` present with `password_ref` + `from_email` + `host`
+
+Config fields:
+
+| Field | Type | Required | Allowed values |
+|------|------|----------|----------------|
+| `recipient` | string | ✅ | FetLife upload email address (string) |
+| `caption_target` | string | ❌ | `subject`, `body`, `both` (default `subject`) |
+| `subject_mode` | string | ❌ | `normal`, `private`, `avatar` (default `normal`) |
+
+### 4.4 `config.email_server`
+
+| Field | Type | Required | Notes |
+|------|------|----------|------|
+| `host` | string | ✅ | SMTP hostname |
+| `port` | int | ❌ | Default `587` |
+| `from_email` | string | ✅ | Sender email address |
+| `password_ref` | string \| null | ❌ | **Required when any `fetlife` publisher is enabled** |
+| `use_tls` | bool | ❌ | Default `true`. Present in schema; **currently ignored by Publisher** |
+| `username` | string \| null | ❌ | Present in schema; **currently ignored by Publisher** |
+
+Publisher behavior (current):
+
+- Always uses **STARTTLS**.
+- Always logs in with **username = `from_email`**.
+
+Therefore:
+
+- The GUI should assume STARTTLS and validate that the chosen SMTP server/port supports it.
+- `use_tls` and `username` can be shown as “reserved / not yet used by Publisher V2”.
+
+### 4.5 `config.ai`
+
+| Field | Type | Required | Notes |
+|------|------|----------|------|
+| `credentials_ref` | string \| null | ✅* | Required to keep `features.analyze_caption_enabled=true` (otherwise Publisher disables AI) |
+| `vision_model` | string \| null | ❌ | Must start with one of: `gpt-4`, `gpt-3.5`, `o1`, `o3` |
+| `caption_model` | string \| null | ❌ | Must start with one of: `gpt-4`, `gpt-3.5`, `o1`, `o3` |
+| `system_prompt` | string \| null | ❌ | Caption system prompt |
+| `role_prompt` | string \| null | ❌ | Caption role/user prompt prefix |
+| `sd_caption_enabled` | bool \| null | ❌ | Stable-Diffusion caption sidecar enable |
+| `sd_caption_single_call_enabled` | bool \| null | ❌ | Prefer one-call `{caption, sd_caption}` |
+| `sd_caption_model` | string \| null | ❌ | Optional override model (Publisher does not validate prefixes for this field today) |
+| `sd_caption_system_prompt` | string \| null | ❌ | Optional override |
+| `sd_caption_role_prompt` | string \| null | ❌ | Optional override |
+
+### 4.6 `config.captionfile`
+
+| Field | Type | Required | Default |
+|------|------|----------|---------|
+| `extended_metadata_enabled` | bool \| null | ❌ | `false` |
+| `artist_alias` | string \| null | ❌ | `null` |
+
+### 4.7 `config.confirmation`
+
+| Field | Type | Required | Default |
+|------|------|----------|---------|
+| `confirmation_to_sender` | bool \| null | ❌ | `true` |
+| `confirmation_tags_count` | int \| null | ❌ | `5` |
+| `confirmation_tags_nature` | string \| null | ❌ | Default guidance string |
+
+Notes:
+
+- Publisher will treat negative values as “0 tags” (slice behavior).
+
+### 4.8 `config.content`
+
+Policy:
+
+- `config.content` should be treated as **platform-managed defaults** and should **not** be end-user editable in the orchestrator GUI.
+- Publisher has safe defaults if this block is omitted.
+
+| Field | Type | Required | Default |
+|------|------|----------|---------|
+| `hashtag_string` | string \| null | ❌ | `""` |
+| `archive` | bool \| null | ❌ | `true` |
+| `debug` | bool \| null | ❌ | `false` |
+
+---
+
+## 5) Credential resolution responses (`POST /v1/credentials/resolve`)
+
+The response is provider-discriminated and must include:
+
+- `provider` (enum)
+- `version` (string)
+
+### 5.1 Provider: `dropbox`
+
+| Field | Type | Required |
+|------|------|----------|
+| `provider` | `"dropbox"` | ✅ |
+| `version` | string | ✅ |
+| `refresh_token` | string | ✅ |
+| `expires_at` | string \| null | ❌ |
+
+### 5.2 Provider: `openai`
+
+| Field | Type | Required |
+|------|------|----------|
+| `provider` | `"openai"` | ✅ |
+| `version` | string | ✅ |
+| `api_key` | string | ✅ |
+
+### 5.3 Provider: `telegram`
+
+| Field | Type | Required |
+|------|------|----------|
+| `provider` | `"telegram"` | ✅ |
+| `version` | string | ✅ |
+| `bot_token` | string | ✅ |
+
+### 5.4 Provider: `smtp`
+
+| Field | Type | Required |
+|------|------|----------|
+| `provider` | `"smtp"` | ✅ |
+| `version` | string | ✅ |
+| `password` | string | ✅ |
+
+---
+
+## 6) Canonical references (do not duplicate)
+
+- Service API guide (auth, host normalization, endpoints):  
+  `docs_v2/02_Specifications/ORCHESTRATOR_SERVICE_API_INTEGRATION_GUIDE.md`
+- Publisher-side mapping + example payload:  
+  `docs_v2/08_Epics/001_multi_tenant_orchestrator_runtime_config/022_orchestrator_schema_v2_integration/022_feature.md`  
+  `docs_v2/08_Epics/001_multi_tenant_orchestrator_runtime_config/022_orchestrator_schema_v2_integration/stories/02_schema_v2_parsing/022_02_schema-v2-parsing.md`
+
+

--- a/docs_v2/02_Specifications/SPECIFICATION.md
+++ b/docs_v2/02_Specifications/SPECIFICATION.md
@@ -12,11 +12,22 @@ This document is the ground truth for implementation. An AI coder can build V2 u
 - Dev tools: black, isort, flake8, mypy, pylint, pytest(+asyncio,+cov), safety, bandit
 
 ## 2. Configuration
-See CONFIGURATION.md for full schema. Validation is mandatory with pydantic v2. Required secrets via `.env`:
-- DROPBOX_APP_KEY, DROPBOX_APP_SECRET, DROPBOX_REFRESH_TOKEN
-- OPENAI_API_KEY (primary)
-- Optional: TELEGRAM_BOT_TOKEN, TELEGRAM_CHANNEL_ID, EMAIL_PASSWORD, INSTA_PASSWORD or Graph API creds
-- Optional SMTP: SMTP_SERVER, SMTP_PORT (defaults: smtp.gmail.com:587)
+See `docs_v2/05_Configuration/CONFIGURATION.md` for the operator-focused guide.
+
+**Default production mode:** orchestrator-backed multi-tenant config (Epic 001 / Feature 022). In this mode:
+
+- Per-tenant runtime config is delivered by the orchestrator runtime endpoint (non-secret).
+- Per-tenant secrets are delivered on-demand via the orchestrator credentials endpoint (secret).
+
+Canonical field-level contract for orchestrator GUI validation:
+
+- `docs_v2/02_Specifications/ORCHESTRATOR_RUNTIME_CONFIG_SCHEMA_REFERENCE.md`
+
+Dyno-required secrets via `.env` (global, not per-tenant):
+
+- `ORCHESTRATOR_BASE_URL`, `ORCHESTRATOR_SERVICE_TOKEN`
+- `DROPBOX_APP_KEY`, `DROPBOX_APP_SECRET`
+- Web/admin secrets as applicable (see `docs_v2/05_Configuration/CONFIGURATION.md`)
 
 INI example keys:
 - [Dropbox] image_folder="/Folder/Sub"; archive="archive"

--- a/docs_v2/03_Architecture/ARCHITECTURE.md
+++ b/docs_v2/03_Architecture/ARCHITECTURE.md
@@ -73,7 +73,9 @@ Web API (FastAPI):
 - `GET /api/admin/status` → AdminStatusResponse (admin session status)
 - `POST /api/admin/login` → AdminStatusResponse (admin login)
 - `POST /api/admin/logout` → AdminStatusResponse (admin logout)
-- `GET /health` → {"status": "ok"}
+- `GET /health/live` → {"status": "ok"} (liveness)
+- `GET /health/ready` → {"status": "ok"} (readiness; may check orchestrator connectivity when configured)
+- `GET /health` → {"status": "ok"} (legacy/compat)
 
 ## 4. Execution Model
 - Async entrypoint; wrap blocking SDK methods with `asyncio.to_thread`.

--- a/docs_v2/08_Epics/001_multi_tenant_orchestrator_runtime_config/README.md
+++ b/docs_v2/08_Epics/001_multi_tenant_orchestrator_runtime_config/README.md
@@ -10,11 +10,13 @@ This epic contains the plan and contract alignment for orchestrator-sourced runt
 
 | ID | Feature | Status |
 |----|---------|--------|
-| 022 | [Orchestrator Schema V2 Integration](022_orchestrator_schema_v2_integration/022_feature.md) | Ready (external contract locked) |
+| 022 | [Orchestrator Schema V2 Integration](022_orchestrator_schema_v2_integration/022_feature.md) | Shipped |
 
 ## Related Specifications
 
 - Orchestrator service-to-service API integration guide:
   - `docs_v2/02_Specifications/ORCHESTRATOR_SERVICE_API_INTEGRATION_GUIDE.md`
+- Orchestrator runtime config schema reference (GUI validation contract):
+  - `docs_v2/02_Specifications/ORCHESTRATOR_RUNTIME_CONFIG_SCHEMA_REFERENCE.md`
 
 

--- a/docs_v2/08_Epics/004_deployment_ops_modernization/012_central_config_i18n_text/stories/01_implementation/MIGRATION_GUIDE.md
+++ b/docs_v2/08_Epics/004_deployment_ops_modernization/012_central_config_i18n_text/stories/01_implementation/MIGRATION_GUIDE.md
@@ -283,7 +283,7 @@ recipient = 12345@upload.fetlife.com
 ### 1. Verify Static Config Loading
 
 ```bash
-cd /Users/evert/Documents/GitHub/SocialMediaPythonPublisher
+# From the repo root:
 uv run python -c "
 from publisher_v2.config.static_loader import get_static_config
 cfg = get_static_config()

--- a/docs_v2/09_Reviews/022_orchestrator_schema_v2_integration_readiness_review.md
+++ b/docs_v2/09_Reviews/022_orchestrator_schema_v2_integration_readiness_review.md
@@ -5,16 +5,20 @@
 **Feature Name:** Orchestrator Schema V2 Integration  
 **Review Date:** December 25, 2025  
 **Reviewer:** QC Engineer (AI Agent)  
-**Feature Status:** Planned  
-**Review Type:** Development Readiness Assessment
+**Feature Status:** Shipped  
+**Review Type:** Development Readiness Assessment (archival)
+
+**Note:** This document was authored as a pre-implementation readiness assessment. Feature 022 is now **Shipped**; for canonical status and validation evidence, see:
+- `docs_v2/08_Epics/001_multi_tenant_orchestrator_runtime_config/022_orchestrator_schema_v2_integration/022_feature.md`
+- `docs_v2/10_Testing/ORCHESTRATOR_INTEGRATION_TEST_REPORT_2025-12-26.md`
 
 ---
 
 ## Executive Summary
 
-Feature 022 has been **thoroughly specified** and is **ready for development** with minor documentation gaps. The feature builds on the completed Feature 021 and integrates with the locked orchestrator contract (Features 10-12). The stories are well-defined with clear acceptance criteria, implementation guidance, and testing plans.
+At the time of this review, Feature 022 was **thoroughly specified** and assessed as **ready for development** with minor documentation gaps. The feature builds on the completed Feature 021 and integrates with the locked orchestrator contract (Features 10-12). The stories are well-defined with clear acceptance criteria, implementation guidance, and testing plans.
 
-### Readiness Verdict: ✅ **READY FOR DEVELOPMENT**
+### Readiness Verdict (at time of review): ✅ **READY FOR DEVELOPMENT**
 
 | Criterion | Status | Notes |
 |-----------|--------|-------|
@@ -229,7 +233,7 @@ Per feature rollout strategy:
 
 ## Conclusion
 
-Feature 022 is **well-specified and ready for development**. All 6 stories are detailed enough for developers to implement with minimal ambiguity. The main remaining actions are:
+At the time of this review, Feature 022 was **well-specified and ready for development**. All 6 stories are detailed enough for developers to implement with minimal ambiguity. The main remaining actions are:
 
 1. **Test fixtures should be created** during Phase 1 (sample v1/v2 orchestrator responses)
 2. **Orchestrator staging access** should be confirmed before Phase 5 integration testing
@@ -239,7 +243,7 @@ The feature represents significant architectural complexity (multi-tenant, crede
 - **Code review by senior engineer** for credential handling (Stories 03/05)
 - **Log auditing** before merge to verify no secret leakage (AC6)
 
-**QA Status:** ✅ **APPROVED FOR DEVELOPMENT**
+**QA Status (at time of review):** ✅ **APPROVED FOR DEVELOPMENT**
 
 ---
 

--- a/docs_v2/09_Reviews/QUALITY_CONTROL_REVIEW_2025-12-21.md
+++ b/docs_v2/09_Reviews/QUALITY_CONTROL_REVIEW_2025-12-21.md
@@ -510,7 +510,7 @@ The following test files contain duplicate Dummy implementations that should be 
 
 ```bash
 # Run all tests
-cd /Users/evert/Documents/GitHub/SocialMediaPythonPublisher
+# From the repo root:
 uv run pytest -v
 
 # Run with coverage report

--- a/docs_v2/09_Reviews/QUALITY_METRICS.md
+++ b/docs_v2/09_Reviews/QUALITY_METRICS.md
@@ -275,7 +275,7 @@ Each QC review produces:
 #!/bin/bash
 # quick_quality_check.sh
 
-cd /Users/evert/Documents/GitHub/SocialMediaPythonPublisher
+# From the repo root:
 
 echo "=== Test Pass Rate ==="
 uv run pytest -q
@@ -297,7 +297,7 @@ uv run flake8 publisher_v2/src/ --count --statistics 2>&1 | tail -3
 #!/bin/bash
 # full_quality_report.sh
 
-cd /Users/evert/Documents/GitHub/SocialMediaPythonPublisher
+# From the repo root:
 
 echo "Running comprehensive quality analysis..."
 

--- a/docs_v2/10_Testing/README.md
+++ b/docs_v2/10_Testing/README.md
@@ -92,7 +92,7 @@ The **current metrics above** are sourced from:
 
 ### Run All Tests
 ```bash
-cd /Users/evert/Documents/GitHub/SocialMediaPythonPublisher
+# From the repo root:
 uv run pytest -v
 ```
 

--- a/docs_v2/10_Testing/TEST_EXECUTION_REPORT_2025-12-21.md
+++ b/docs_v2/10_Testing/TEST_EXECUTION_REPORT_2025-12-21.md
@@ -229,7 +229,7 @@ return templates.TemplateResponse(
 
 ### Run All Tests
 ```bash
-cd /Users/evert/Documents/GitHub/SocialMediaPythonPublisher
+# From the repo root:
 uv run pytest -v
 ```
 

--- a/docs_v2/README.md
+++ b/docs_v2/README.md
@@ -8,7 +8,7 @@ This directory is the **canonical documentation set** for V2 (architecture, spec
 - **Implementation spec (ground truth)**: `02_Specifications/SPECIFICATION.md`
 - **System design + architecture**: `03_Architecture/SYSTEM_DESIGN.md`, `03_Architecture/ARCHITECTURE.md`
 - **Configuration**: `05_Configuration/CONFIGURATION.md`
-- **Features + stories**: `08_Epics/README.md`, `08_Epics/INDEX.md`
+- **Features + stories**: `08_Epics/README.md`
 - **Testing**: `10_Testing/README.md`
 - **Quality + reviews**: `09_Reviews/QUALITY_METRICS.md`, `09_Reviews/QUALITY_CONTROL_REVIEW_2025-12-21.md`
 

--- a/publisher_v2/tests/test_ai_sd_generate.py
+++ b/publisher_v2/tests/test_ai_sd_generate.py
@@ -1,26 +1,13 @@
 from __future__ import annotations
 
-import asyncio
-import types
 import pytest
 
 from publisher_v2.config.schema import OpenAIConfig
 from publisher_v2.core.models import CaptionSpec, ImageAnalysis
-from publisher_v2.services.ai import CaptionGeneratorOpenAI, AIService, VisionAnalyzerOpenAI
+from publisher_v2.services.ai import CaptionGeneratorOpenAI, AIService
 
-
-class DummyAnalyzer(VisionAnalyzerOpenAI):
-    def __init__(self) -> None:
-        pass
-
-    async def analyze(self, url_or_bytes: str | bytes) -> ImageAnalysis:
-        return ImageAnalysis(
-            description="A serene portrait of a dancer",
-            mood="calm",
-            tags=["portrait", "dancer"],
-            nsfw=False,
-            safety_labels=[],
-        )
+# Use centralized test fixtures from conftest.py (QC-001)
+from conftest import BaseDummyAnalyzer
 
 
 @pytest.mark.asyncio
@@ -34,7 +21,7 @@ async def test_ai_generate_with_sd_pair_parsing(monkeypatch: pytest.MonkeyPatch)
 
     monkeypatch.setattr(gen, "generate_with_sd", fake_generate_with_sd)
 
-    ai = AIService(analyzer=DummyAnalyzer(), generator=gen)
+    ai = AIService(analyzer=BaseDummyAnalyzer(), generator=gen)
 
     spec = CaptionSpec(platform="generic", style="minimal", hashtags="#tag", max_length=100)
     caption, sd_caption = await ai.create_caption_pair("http://tmp", spec)
@@ -56,7 +43,7 @@ async def test_ai_generate_with_sd_from_existing_analysis(monkeypatch: pytest.Mo
 
     monkeypatch.setattr(gen, "generate_with_sd", fake_generate_with_sd)
 
-    analyzer = DummyAnalyzer()
+    analyzer = BaseDummyAnalyzer()
     ai = AIService(analyzer=analyzer, generator=gen)
 
     spec = CaptionSpec(platform="generic", style="minimal", hashtags="#tag", max_length=100)

--- a/publisher_v2/tests/test_archive_with_sidecar.py
+++ b/publisher_v2/tests/test_archive_with_sidecar.py
@@ -1,24 +1,12 @@
 from __future__ import annotations
 
-from typing import List, Tuple
-
 import pytest
 
 from publisher_v2.config.schema import DropboxConfig
 from publisher_v2.services.storage import DropboxStorage
 
-
-class DummyClient:
-    def __init__(self) -> None:
-        self.moves: List[Tuple[str, str]] = []
-        self.created: List[str] = []
-
-    def files_create_folder_v2(self, path: str) -> None:
-        self.created.append(path)
-
-    def files_move_v2(self, src: str, dst: str, autorename: bool = False) -> None:
-        # record moves; ignore not-found for sidecar by simply recording
-        self.moves.append((src, dst))
+# Use centralized test fixtures from conftest.py (QC-001)
+from conftest import BaseDummyClient
 
 
 @pytest.mark.asyncio
@@ -31,7 +19,8 @@ async def test_archive_moves_image_and_sidecar(monkeypatch: pytest.MonkeyPatch) 
         archive_folder="archive",
     )
     storage = DropboxStorage(cfg)
-    client = DummyClient()
+    # Use centralized fixture (QC-001)
+    client = BaseDummyClient()
     monkeypatch.setattr(storage, "client", client)
 
     await storage.archive_image("/ImagesToday", "image.jpg", "archive")

--- a/publisher_v2/tests/test_dropbox_keep_remove_move.py
+++ b/publisher_v2/tests/test_dropbox_keep_remove_move.py
@@ -1,36 +1,14 @@
 from __future__ import annotations
 
-from types import SimpleNamespace
-from typing import List, Optional
+from typing import Optional
 
 import pytest
-from dropbox.exceptions import ApiError
 
 from publisher_v2.config.schema import DropboxConfig
 from publisher_v2.services.storage import DropboxStorage
 
-
-class DummyClient:
-    def __init__(self) -> None:
-        self.created_dirs: List[str] = []
-        self.moves: List[tuple[str, str]] = []
-        self.sidecar_exists: bool = True
-
-    def files_create_folder_v2(self, path: str) -> None:
-        self.created_dirs.append(path)
-
-    def files_move_v2(self, from_path: str, to_path: str, autorename: bool = False) -> None:
-        # Simulate sidecar missing by raising ApiError when appropriate.
-        if from_path.endswith("image.txt") and not self.sidecar_exists:
-            class _Error:
-                def is_path(self) -> bool:
-                    return True
-
-                def get_path(self) -> SimpleNamespace:
-                    return SimpleNamespace(is_not_found=lambda: True)
-
-            raise ApiError("req", _Error(), "not_found", "en-US")
-        self.moves.append((from_path, to_path))
+# Use centralized test fixtures from conftest.py (QC-001)
+from conftest import BaseDummyClient
 
 
 @pytest.mark.asyncio
@@ -43,7 +21,8 @@ async def test_move_image_with_sidecars_moves_image_and_txt(monkeypatch: pytest.
         archive_folder="archive",
     )
     storage = DropboxStorage(cfg)
-    dummy = DummyClient()
+    # Use centralized fixture (QC-001)
+    dummy = BaseDummyClient(sidecar_exists=True)
     monkeypatch.setattr(storage, "client", dummy)
 
     await storage.move_image_with_sidecars("/ImagesToday", "image.jpg", "keep")
@@ -64,8 +43,8 @@ async def test_move_image_with_sidecars_ignores_missing_sidecar(monkeypatch: pyt
         archive_folder="archive",
     )
     storage = DropboxStorage(cfg)
-    dummy = DummyClient()
-    dummy.sidecar_exists = False
+    # Use centralized fixture (QC-001)
+    dummy = BaseDummyClient(sidecar_exists=False)
     monkeypatch.setattr(storage, "client", dummy)
 
     # Should not raise when sidecar is missing; only the image must move.

--- a/publisher_v2/tests/test_dropbox_sidecar.py
+++ b/publisher_v2/tests/test_dropbox_sidecar.py
@@ -1,42 +1,12 @@
 from __future__ import annotations
 
-from types import SimpleNamespace
-from typing import Any, List, Optional
-
 import pytest
-from dropbox.exceptions import ApiError
 
 from publisher_v2.config.schema import DropboxConfig
 from publisher_v2.services.storage import DropboxStorage
 
-
-class DummyClient:
-    def __init__(self) -> None:
-        self.uploads: List[tuple[str, bytes, Any]] = []
-        self.sidecar_bytes: Optional[bytes] = None
-        self.sidecar_exists: bool = True
-
-    def files_upload(self, data: bytes, path: str, mode: Any, mute: bool = False, strict_conflict: bool = False) -> None:
-        self.uploads.append((path, data, mode))
-
-    def files_download(self, path: str) -> tuple[None, SimpleNamespace]:
-        # Simple emulation: only support sidecar path, and respect sidecar_exists flag.
-        if not self.sidecar_exists:
-            # Build a minimal ApiError with a .error exposing is_path()/get_path().is_not_found()
-            class _PathError:
-                def is_not_found(self) -> bool:
-                    return True
-
-            class _Error:
-                def is_path(self) -> bool:
-                    return True
-
-                def get_path(self) -> _PathError:
-                    return _PathError()
-
-            raise ApiError("request-id", _Error(), "not_found", "en-US")
-        content = self.sidecar_bytes or b"sidecar-bytes"
-        return None, SimpleNamespace(content=content)
+# Use centralized test fixtures from conftest.py (QC-001)
+from conftest import BaseDummyClient
 
 
 @pytest.mark.asyncio
@@ -49,7 +19,8 @@ async def test_sidecar_upload_overwrite(monkeypatch: pytest.MonkeyPatch) -> None
         archive_folder="archive",
     )
     storage = DropboxStorage(cfg)
-    dummy = DummyClient()
+    # Use centralized fixture (QC-001)
+    dummy = BaseDummyClient()
     monkeypatch.setattr(storage, "client", dummy)
 
     await storage.write_sidecar_text("/ImagesToday", "image.jpg", "sd caption")
@@ -70,9 +41,9 @@ async def test_download_sidecar_if_exists_returns_bytes(monkeypatch: pytest.Monk
         archive_folder="archive",
     )
     storage = DropboxStorage(cfg)
-    dummy = DummyClient()
+    # Use centralized fixture (QC-001)
+    dummy = BaseDummyClient(sidecar_exists=True)
     dummy.sidecar_bytes = b"hello-sidecar"
-    dummy.sidecar_exists = True
     monkeypatch.setattr(storage, "client", dummy)
 
     blob = await storage.download_sidecar_if_exists("/ImagesToday", "image.jpg")
@@ -89,8 +60,8 @@ async def test_download_sidecar_if_exists_returns_none_on_not_found(monkeypatch:
         archive_folder="archive",
     )
     storage = DropboxStorage(cfg)
-    dummy = DummyClient()
-    dummy.sidecar_exists = False
+    # Use centralized fixture (QC-001)
+    dummy = BaseDummyClient(sidecar_exists=False)
     monkeypatch.setattr(storage, "client", dummy)
 
     blob = await storage.download_sidecar_if_exists("/ImagesToday", "image.jpg")

--- a/publisher_v2/tests/test_e2e_sd_caption.py
+++ b/publisher_v2/tests/test_e2e_sd_caption.py
@@ -9,67 +9,39 @@ from publisher_v2.config.schema import (
     OpenAIConfig,
     PlatformsConfig,
 )
-from publisher_v2.core.models import ImageAnalysis, CaptionSpec, PublishResult
+from publisher_v2.core.models import ImageAnalysis, CaptionSpec
 from publisher_v2.core.workflow import WorkflowOrchestrator
-from publisher_v2.services.ai import AIService, CaptionGeneratorOpenAI, VisionAnalyzerOpenAI
-from publisher_v2.services.storage import DropboxStorage
-from publisher_v2.services.publishers.base import Publisher
+from publisher_v2.services.ai import AIService, CaptionGeneratorOpenAI
+
+# Use centralized test fixtures from conftest.py (QC-001)
+from conftest import BaseDummyStorage, BaseDummyAnalyzer, BaseDummyGenerator, BaseDummyPublisher
 
 
-class DummyAnalyzer(VisionAnalyzerOpenAI):
-    def __init__(self) -> None:
-        pass
-
-    async def analyze(self, url_or_bytes: str | bytes) -> ImageAnalysis:
-        return ImageAnalysis(description="desc", mood="mood", tags=["t"], nsfw=False, safety_labels=[])
-
-
-class DummyGenerator(CaptionGeneratorOpenAI):
+class SDCaptionGenerator(BaseDummyGenerator):
+    """Generator that supports SD caption generation."""
     def __init__(self, cfg: OpenAIConfig) -> None:
-        super().__init__(cfg)
+        super().__init__(caption="normal caption", sd_caption="fine-art portrait, soft light, calm mood")
+        self.model = cfg.caption_model
 
     async def generate_with_sd(self, analysis: ImageAnalysis, spec: CaptionSpec) -> dict[str, str]:
-        return {"caption": "normal caption", "sd_caption": "fine-art portrait, soft light, calm mood"}
+        return {"caption": self._caption, "sd_caption": self._sd_caption}
 
     async def generate(self, analysis: ImageAnalysis, spec: CaptionSpec) -> str:
         return "legacy caption"
 
 
-class DummyStorage(DropboxStorage):
-    def __init__(self, cfg: DropboxConfig) -> None:
-        self.config = cfg
+class TrackingStorage(BaseDummyStorage):
+    """Storage that tracks sidecars and archives for assertions."""
+    def __init__(self) -> None:
+        super().__init__()
         self.sidecars = 0
         self.archived = 0
-
-    async def list_images(self, folder: str):
-        return ["image.jpg"]
-
-    async def download_image(self, folder: str, filename: str) -> bytes:
-        return b"data"
-
-    async def get_temporary_link(self, folder: str, filename: str) -> str:
-        return "http://tmp"
-
-    async def get_file_metadata(self, folder: str, filename: str):
-        return {"id": "id:XYZ", "rev": "123"}
 
     async def write_sidecar_text(self, folder: str, filename: str, text: str) -> None:
         self.sidecars += 1
 
     async def archive_image(self, folder: str, filename: str, archive_folder: str) -> None:
         self.archived += 1
-
-
-class DummyPublisher(Publisher):
-    @property
-    def platform_name(self) -> str:
-        return "dummy"
-
-    def is_enabled(self) -> bool:
-        return True
-
-    async def publish(self, image_path: str, caption: str, context: dict | None = None) -> PublishResult:
-        return PublishResult(success=True, platform=self.platform_name)
 
 
 def make_config(archive: bool) -> ApplicationConfig:
@@ -94,21 +66,21 @@ async def test_e2e_preview_then_live_sd_caption(monkeypatch: pytest.MonkeyPatch)
     monkeypatch.setattr("publisher_v2.core.workflow.load_posted_hashes", lambda: set())
     monkeypatch.setattr("publisher_v2.core.workflow.save_posted_hash", lambda h: None)
     
-    # Preview phase
+    # Preview phase - use centralized fixtures (QC-001)
     cfg_prev = make_config(archive=True)
-    storage_prev = DummyStorage(cfg_prev.dropbox)
-    ai_prev = AIService(DummyAnalyzer(), DummyGenerator(cfg_prev.openai))
-    orch_prev = WorkflowOrchestrator(config=cfg_prev, storage=storage_prev, ai_service=ai_prev, publishers=[DummyPublisher()])
+    storage_prev = TrackingStorage()
+    ai_prev = AIService(BaseDummyAnalyzer(), SDCaptionGenerator(cfg_prev.openai))
+    orch_prev = WorkflowOrchestrator(config=cfg_prev, storage=storage_prev, ai_service=ai_prev, publishers=[BaseDummyPublisher()])
     result_prev = await orch_prev.execute(preview_mode=True)
     assert result_prev.image_analysis is not None
     assert getattr(result_prev.image_analysis, "sd_caption", None)
     assert storage_prev.sidecars == 0  # no side effects in preview
 
-    # Live phase
+    # Live phase - use centralized fixtures (QC-001)
     cfg_live = make_config(archive=True)
-    storage_live = DummyStorage(cfg_live.dropbox)
-    ai_live = AIService(DummyAnalyzer(), DummyGenerator(cfg_live.openai))
-    orch_live = WorkflowOrchestrator(config=cfg_live, storage=storage_live, ai_service=ai_live, publishers=[DummyPublisher()])
+    storage_live = TrackingStorage()
+    ai_live = AIService(BaseDummyAnalyzer(), SDCaptionGenerator(cfg_live.openai))
+    orch_live = WorkflowOrchestrator(config=cfg_live, storage=storage_live, ai_service=ai_live, publishers=[BaseDummyPublisher()])
     result_live = await orch_live.execute(preview_mode=False)
     assert storage_live.sidecars == 1
     # With a successful publisher and archive enabled, archive is called

--- a/publisher_v2/tests/test_orchestrator_debug.py
+++ b/publisher_v2/tests/test_orchestrator_debug.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
-import os
-from typing import Dict, List
 
 import pytest
 
@@ -15,80 +12,10 @@ from publisher_v2.config.schema import (
     OpenAIConfig,
     PlatformsConfig,
 )
-from publisher_v2.core.models import CaptionSpec, PublishResult
 from publisher_v2.core.workflow import WorkflowOrchestrator
-from publisher_v2.services.ai import AIService
-from publisher_v2.services.publishers.base import Publisher
-from publisher_v2.services.storage import DropboxStorage
 
-
-class DummyStorage(DropboxStorage):
-    def __init__(self):
-        # Bypass parent init
-        self.config = DropboxConfig(
-            app_key="k", app_secret="s", refresh_token="r", image_folder="/Photos", archive_folder="archive"
-        )
-
-    async def list_images(self, folder: str) -> List[str]:
-        return ["test.jpg"]
-
-    async def download_image(self, folder: str, filename: str) -> bytes:
-        return b"\x89PNG\r\n\x1a\n"
-
-    async def get_temporary_link(self, folder: str, filename: str) -> str:
-        return "https://example.com/tmp/test.jpg"
-
-    async def archive_image(self, folder: str, filename: str, archive_folder: str) -> None:
-        return None
-
-
-class DummyAnalyzer:
-    async def analyze(self, url_or_bytes: str | bytes):
-        from publisher_v2.core.models import ImageAnalysis
-        return ImageAnalysis(
-            description="Test image",
-            mood="neutral",
-            tags=["test"],
-            nsfw=False,
-            safety_labels=[],
-        )
-
-
-class DummyGenerator:
-    async def generate(self, analysis, spec: CaptionSpec) -> str:
-        return "hello world #tags"
-
-
-class DummyAI(AIService):
-    def __init__(self):
-        self._caption = "hello world #tags"
-        self.analyzer = DummyAnalyzer()
-        self.generator = DummyGenerator()
-        # Provide a no-op rate limiter compatible with AIService usage.
-        class _NoopLimiter:
-            async def __aenter__(self) -> None:  # type: ignore[override]
-                return None
-
-            async def __aexit__(self, exc_type, exc, tb) -> bool:  # type: ignore[override]
-                return False
-
-        self._rate_limiter = _NoopLimiter()
-
-    async def create_caption(self, url_or_bytes: str | bytes, spec: CaptionSpec) -> str:
-        return self._caption
-
-
-class DummyPublisher(Publisher):
-    @property
-    def platform_name(self) -> str:
-        return "dummy"
-
-    def is_enabled(self) -> bool:
-        return True
-
-    async def publish(self, image_path: str, caption: str) -> PublishResult:
-        # Should not be called in debug mode
-        return PublishResult(success=False, platform=self.platform_name, error="should not be called")
+# Use centralized test fixtures from conftest.py (QC-001)
+from conftest import BaseDummyStorage, BaseDummyAI, BaseDummyPublisher
 
 
 @pytest.mark.asyncio
@@ -104,9 +31,10 @@ async def test_orchestrator_debug_mode_skips_publish_and_no_archive(tmp_path):
         email=None,
         content=ContentConfig(hashtag_string="#tags", archive=True, debug=True),
     )
-    storage = DummyStorage()
-    ai = DummyAI()
-    publishers = [DummyPublisher()]
+    # Use centralized fixtures (QC-001)
+    storage = BaseDummyStorage()
+    ai = BaseDummyAI()
+    publishers = [BaseDummyPublisher()]
     orchestrator = WorkflowOrchestrator(cfg, storage, ai, publishers)
     result = await orchestrator.execute()
 
@@ -131,9 +59,10 @@ async def test_orchestrator_emits_timing_log(tmp_path, caplog: pytest.LogCapture
         email=None,
         content=ContentConfig(hashtag_string="#tags", archive=True, debug=True),
     )
-    storage = DummyStorage()
-    ai = DummyAI()
-    publishers = [DummyPublisher()]
+    # Use centralized fixtures (QC-001)
+    storage = BaseDummyStorage()
+    ai = BaseDummyAI()
+    publishers = [BaseDummyPublisher()]
     orchestrator = WorkflowOrchestrator(cfg, storage, ai, publishers)
 
     caplog.set_level(logging.INFO, logger="publisher_v2.workflow")

--- a/publisher_v2/tests/test_workflow_sd_integration.py
+++ b/publisher_v2/tests/test_workflow_sd_integration.py
@@ -1,8 +1,5 @@
 from __future__ import annotations
 
-import asyncio
-import hashlib
-import os
 import pytest
 
 from publisher_v2.config.schema import (
@@ -14,53 +11,33 @@ from publisher_v2.config.schema import (
 )
 from publisher_v2.core.models import ImageAnalysis, CaptionSpec
 from publisher_v2.core.workflow import WorkflowOrchestrator
-from publisher_v2.services.ai import AIService, CaptionGeneratorOpenAI, VisionAnalyzerOpenAI
-from publisher_v2.services.storage import DropboxStorage
-from publisher_v2.services.publishers.base import Publisher
+from publisher_v2.services.ai import AIService, CaptionGeneratorOpenAI
+
+# Use centralized test fixtures from conftest.py (QC-001)
+from conftest import BaseDummyStorage, BaseDummyAnalyzer, BaseDummyGenerator
 
 
-class DummyAnalyzer(VisionAnalyzerOpenAI):
-    def __init__(self) -> None:
-        pass
-
-    async def analyze(self, url_or_bytes: str | bytes) -> ImageAnalysis:
-        return ImageAnalysis(description="desc", mood="mood", tags=["t"], nsfw=False, safety_labels=[])
-
-
-class DummyGenerator(CaptionGeneratorOpenAI):
+class SDCaptionGenerator(BaseDummyGenerator):
+    """Generator that supports SD caption generation."""
     def __init__(self, cfg: OpenAIConfig) -> None:
-        super().__init__(cfg)
+        super().__init__(caption="normal caption", sd_caption="fine-art portrait, soft light, calm mood")
+        self.model = cfg.caption_model
 
     async def generate_with_sd(self, analysis: ImageAnalysis, spec: CaptionSpec) -> dict[str, str]:
-        return {"caption": "normal caption", "sd_caption": "fine-art portrait, soft light, calm mood"}
+        return {"caption": self._caption, "sd_caption": self._sd_caption}
 
     async def generate(self, analysis: ImageAnalysis, spec: CaptionSpec) -> str:
         return "legacy caption"
 
 
-class DummyStorage(DropboxStorage):
-    def __init__(self, cfg: DropboxConfig) -> None:
-        self.config = cfg
+class TrackingStorage(BaseDummyStorage):
+    """Storage that tracks writes and archives for assertions."""
+    def __init__(self) -> None:
+        super().__init__()
         self.writes = 0
-        self.archives = 0
-
-    async def list_images(self, folder: str):
-        return ["image.jpg"]
-
-    async def download_image(self, folder: str, filename: str) -> bytes:
-        return b"data"
-
-    async def get_temporary_link(self, folder: str, filename: str) -> str:
-        return "http://tmp"
-
-    async def get_file_metadata(self, folder: str, filename: str):
-        return {"id": "id:XYZ", "rev": "123"}
 
     async def write_sidecar_text(self, folder: str, filename: str, text: str) -> None:
         self.writes += 1
-
-    async def archive_image(self, folder: str, filename: str, archive_folder: str) -> None:
-        self.archives += 1
 
 
 def make_config() -> ApplicationConfig:
@@ -82,8 +59,9 @@ def make_config() -> ApplicationConfig:
 @pytest.mark.asyncio
 async def test_workflow_sd_integration_preview_and_live(monkeypatch: pytest.MonkeyPatch) -> None:
     cfg = make_config()
-    storage = DummyStorage(cfg.dropbox)
-    ai = AIService(DummyAnalyzer(), DummyGenerator(cfg.openai))
+    # Use centralized fixtures (QC-001)
+    storage = TrackingStorage()
+    ai = AIService(BaseDummyAnalyzer(), SDCaptionGenerator(cfg.openai))
     cgf = cfg
     orchestrator = WorkflowOrchestrator(config=cgf, storage=storage, ai_service=ai, publishers=[])
     # Ensure dedup state does not block the test


### PR DESCRIPTION
## Summary
Documentation and test suite cleanup related to orchestrator integration.

## Changes
- Update `docs_v2` overview/spec/architecture/config and epic README organization.
- Add `docs_v2/02_Specifications/ORCHESTRATOR_RUNTIME_CONFIG_SCHEMA_REFERENCE.md`.
- Clean up and simplify several tests (no behavior change intended).

## Testing
- `uv run pytest -q` → **437 passed**
