### PR TITLE
Update platform support status in Smart Hashtag Generation roadmap

### DIFF
--- a/PROPOSED_CHANGES.md
+++ b/PROPOSED_CHANGES.md
@@ -1,0 +1,22 @@
+**File:** `docs_v2/roadmap/PUB-028_smart-hashtag-generation.md`
+
+This PR updates the roadmap for Smart Hashtag Generation to accurately reflect the implementation status of various social media platforms. 
+
+Changes based on workspace observations:
+- Marked Mastodon as 'Planning/Not Active' (Observations 1, 6).
+- Marked Bluesky as 'Planning/Not Implemented' (Observations 3, 5).
+- Flagged Instagram as 'No longer viable/supported' (Observations 2, 4).
+
+These updates ensure the documentation matches the actual state of the project integration and prevents user confusion regarding supported features.
+
+```diff
+--- a/docs_v2/roadmap/PUB-028_smart-hashtag-generation.md
++++ b/docs_v2/roadmap/PUB-028_smart-hashtag-generation.md
+@@ -12,9 +12,9 @@
+- - [x] Instagram
+- - [x] Mastodon
+- - [x] Bluesky
++ - [ ] Instagram (No longer supported)
++ - [ ] Mastodon (Planning phase)
++ - [ ] Bluesky (Planning phase)
+```


### PR DESCRIPTION
## Knowledge Improvement Proposal

**File:** `docs_v2/roadmap/PUB-028_smart-hashtag-generation.md`

This PR updates the roadmap for Smart Hashtag Generation to accurately reflect the implementation status of various social media platforms. 

Changes based on workspace observations:
- Marked Mastodon as 'Planning/Not Active' (Observations 1, 6).
- Marked Bluesky as 'Planning/Not Implemented' (Observations 3, 5).
- Flagged Instagram as 'No longer viable/supported' (Observations 2, 4).

These updates ensure the documentation matches the actual state of the project integration and prevents user confusion regarding supported features.

---
*Generated by [Agent Smit](https://github.com/agent-smit) from 6 observation(s).*
