### PR TITLE
Remove Instagram from distribution design specifications

### DIFF
--- a/PROPOSED_CHANGES.md
+++ b/PROPOSED_CHANGES.md
@@ -1,0 +1,19 @@
+Observations 1, 2, and 4 indicate that Instagram is no longer a supported or active platform in the SocialMediaPythonPublisher project. The documentation in `docs_v1/DESIGN_SPECIFICATIONS.md` currently includes Instagram in the multi-platform distribution flow. This PR removes the obsolete Instagram distribution target to ensure the design specifications accurately reflect the current system architecture.
+
+```diff
+--- a/docs_v1/DESIGN_SPECIFICATIONS.md
++++ b/docs_v1/DESIGN_SPECIFICATIONS.md
+@@ -32,7 +32,6 @@
+ ┌─────────────────────────────────────────────────────────────┐
+ │              5. Multi-Platform Distribution                  │
+ │                                                              │
+-│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐     │
+-│  │  Instagram   │  │   Telegram   │  │    Email     │     │
+-│  │   (async)    │  │   (async)    │  │   (async)    │     │
+-│  └──────────────┘  └──────────────┘  └──────────────┘     │
++│  ┌──────────────┐  ┌──────────────┐                       │
++│  │   Telegram   │  │    Email     │                       │
++│  │   (async)    │  │   (async)    │                       │
++│  └──────────────┘  └──────────────┘                       │
+ └─────────────────────────────────────────────────────────────┘
+```


### PR DESCRIPTION
## Knowledge Improvement Proposal

Observations 1, 2, and 4 indicate that Instagram is no longer a supported or active platform in the SocialMediaPythonPublisher project. The documentation in `docs_v1/DESIGN_SPECIFICATIONS.md` currently includes Instagram in the multi-platform distribution flow. This PR removes the obsolete Instagram distribution target to ensure the design specifications accurately reflect the current system architecture.

---
*Generated by [Agent Smit](https://github.com/agent-smit) from 4 observation(s).*
